### PR TITLE
feat: open transaction modal from floating quick entry

### DIFF
--- a/components/client/client-wrapper.tsx
+++ b/components/client/client-wrapper.tsx
@@ -9,6 +9,7 @@ import { APP_VERSION } from '@/lib/env';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import React, { JSX, useEffect } from 'react';
+import { FloatingQuickEntry } from './floating-quick-entry';
 
 function ClientWrapper({ children }: { children: React.ReactNode }): JSX.Element {
   const router = useRouter();
@@ -57,6 +58,7 @@ function ClientWrapper({ children }: { children: React.ReactNode }): JSX.Element
       <LanguageProvider>
         <ProfileProvider>
           {children}
+          <FloatingQuickEntry />
         </ProfileProvider>
       </LanguageProvider>
     </QueryClientProvider>

--- a/components/client/floating-quick-entry.tsx
+++ b/components/client/floating-quick-entry.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { Button } from '@/components/ui/button';
-import { Textarea } from '@/components/ui/textarea';
+import { AddTransactionModal } from '@/components/modals/add-transaction-modal';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 type Position = {
@@ -17,7 +16,6 @@ const STORAGE_KEY = 'owwi.newui:floating-quick-entry-position';
 export function FloatingQuickEntry() {
   const [isOpen, setIsOpen] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
-  const [draft, setDraft] = useState('');
   const [position, setPosition] = useState<Position>({ x: 0, y: 0 });
   const bubbleRef = useRef<HTMLButtonElement | null>(null);
   const dragStateRef = useRef({
@@ -136,45 +134,10 @@ export function FloatingQuickEntry() {
 
   const bubbleStyle = useMemo(() => ({ left: `${position.x}px`, top: `${position.y}px` }), [position.x, position.y]);
 
-  if (isOpen) {
-    return (
-      <div className="fixed inset-0 z-[70] flex items-center justify-center px-4">
-        <div className="absolute inset-0 bg-black/30 backdrop-blur-[2px]" onClick={() => setIsOpen(false)} />
-        <div className="relative z-[71] w-full max-w-md rounded-3xl border border-white/30 bg-white/75 p-5 shadow-2xl backdrop-blur-xl dark:border-white/10 dark:bg-slate-900/80">
-          <button
-            type="button"
-            onClick={() => setIsOpen(false)}
-            className="absolute right-4 top-4 flex h-8 w-8 items-center justify-center rounded-full bg-black/5 text-slate-500 transition hover:bg-black/10 hover:text-slate-700 dark:bg-white/10 dark:text-slate-300 dark:hover:bg-white/20"
-          >
-            <span className="text-lg leading-none">×</span>
-          </button>
-
-          <div className="pr-10">
-            <h2 className="text-xl font-semibold text-slate-900 dark:text-white">Nhập giao dịch</h2>
-            <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
-              Nhập nhanh giao dịch của bạn với AI thông minh.
-            </p>
-          </div>
-
-          <div className="mt-5 space-y-4">
-            <Textarea
-              value={draft}
-              onChange={(event) => setDraft(event.target.value)}
-              placeholder="Ăn trưa 30k"
-              rows={5}
-              className="rounded-2xl border-white/40 bg-white/70 backdrop-blur dark:bg-slate-800/70"
-            />
-            <Button type="button" className="w-full rounded-2xl" onClick={() => setIsOpen(false)}>
-              Xác nhận
-            </Button>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <button
+    <>
+      <AddTransactionModal isOpen={isOpen} onClose={() => setIsOpen(false)} />
+      <button
       ref={bubbleRef}
       type="button"
       aria-label="Mở nhập giao dịch nhanh"
@@ -195,6 +158,7 @@ export function FloatingQuickEntry() {
       }}
     >
       <span className="pointer-events-none select-none text-3xl font-light leading-none">+</span>
-    </button>
+      </button>
+    </>
   );
 }

--- a/components/client/floating-quick-entry.tsx
+++ b/components/client/floating-quick-entry.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+type Position = {
+  x: number;
+  y: number;
+};
+
+const FLOATING_SIZE = 56;
+const MARGIN = 16;
+const DRAG_THRESHOLD = 6;
+
+export function FloatingQuickEntry() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+  const [draft, setDraft] = useState('');
+  const [position, setPosition] = useState<Position>({ x: 0, y: 0 });
+  const bubbleRef = useRef<HTMLButtonElement | null>(null);
+  const dragStateRef = useRef({
+    pointerId: -1,
+    startX: 0,
+    startY: 0,
+    originX: 0,
+    originY: 0,
+    moved: false,
+  });
+
+  useEffect(() => {
+    const syncInitialPosition = () => {
+      setPosition({
+        x: window.innerWidth - FLOATING_SIZE - MARGIN,
+        y: window.innerHeight - FLOATING_SIZE - 96,
+      });
+    };
+
+    syncInitialPosition();
+    window.addEventListener('resize', syncInitialPosition);
+    return () => window.removeEventListener('resize', syncInitialPosition);
+  }, []);
+
+  const clampPosition = useCallback((nextX: number, nextY: number) => {
+    const maxX = Math.max(MARGIN, window.innerWidth - FLOATING_SIZE - MARGIN);
+    const maxY = Math.max(MARGIN, window.innerHeight - FLOATING_SIZE - MARGIN);
+    return {
+      x: Math.min(Math.max(MARGIN, nextX), maxX),
+      y: Math.min(Math.max(MARGIN, nextY), maxY),
+    };
+  }, []);
+
+  const handlePointerDown = useCallback((event: React.PointerEvent<HTMLButtonElement>) => {
+    dragStateRef.current = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startY: event.clientY,
+      originX: position.x,
+      originY: position.y,
+      moved: false,
+    };
+    event.currentTarget.setPointerCapture(event.pointerId);
+    setIsDragging(false);
+  }, [position.x, position.y]);
+
+  const handlePointerMove = useCallback((event: React.PointerEvent<HTMLButtonElement>) => {
+    const state = dragStateRef.current;
+    if (state.pointerId !== event.pointerId) return;
+
+    const deltaX = event.clientX - state.startX;
+    const deltaY = event.clientY - state.startY;
+    const distance = Math.hypot(deltaX, deltaY);
+
+    if (distance > DRAG_THRESHOLD) {
+      state.moved = true;
+      setIsDragging(true);
+    }
+
+    if (!state.moved) return;
+
+    const next = clampPosition(state.originX + deltaX, state.originY + deltaY);
+    setPosition(next);
+  }, [clampPosition]);
+
+  const finishPointer = useCallback((event: React.PointerEvent<HTMLButtonElement>) => {
+    const state = dragStateRef.current;
+    if (state.pointerId !== event.pointerId) return;
+
+    event.currentTarget.releasePointerCapture(event.pointerId);
+    const didMove = state.moved;
+
+    dragStateRef.current = {
+      pointerId: -1,
+      startX: 0,
+      startY: 0,
+      originX: 0,
+      originY: 0,
+      moved: false,
+    };
+
+    setTimeout(() => setIsDragging(false), 0);
+
+    if (!didMove) {
+      setIsOpen(true);
+    }
+  }, []);
+
+  const bubbleStyle = useMemo(() => ({ left: `${position.x}px`, top: `${position.y}px` }), [position.x, position.y]);
+
+  if (isOpen) {
+    return (
+      <div className="fixed inset-0 z-[70] flex items-center justify-center px-4">
+        <div className="absolute inset-0 bg-black/30 backdrop-blur-[2px]" onClick={() => setIsOpen(false)} />
+        <div className="relative z-[71] w-full max-w-md rounded-3xl border border-white/30 bg-white/75 p-5 shadow-2xl backdrop-blur-xl dark:border-white/10 dark:bg-slate-900/80">
+          <button
+            type="button"
+            onClick={() => setIsOpen(false)}
+            className="absolute right-4 top-4 flex h-8 w-8 items-center justify-center rounded-full bg-black/5 text-slate-500 transition hover:bg-black/10 hover:text-slate-700 dark:bg-white/10 dark:text-slate-300 dark:hover:bg-white/20"
+          >
+            <span className="text-lg leading-none">×</span>
+          </button>
+
+          <div className="pr-10">
+            <h2 className="text-xl font-semibold text-slate-900 dark:text-white">Nhập giao dịch</h2>
+            <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+              Nhập nhanh giao dịch của bạn với AI thông minh.
+            </p>
+          </div>
+
+          <div className="mt-5 space-y-4">
+            <Textarea
+              value={draft}
+              onChange={(event) => setDraft(event.target.value)}
+              placeholder="Ăn trưa 30k"
+              rows={5}
+              className="rounded-2xl border-white/40 bg-white/70 backdrop-blur dark:bg-slate-800/70"
+            />
+            <Button type="button" className="w-full rounded-2xl" onClick={() => setIsOpen(false)}>
+              Xác nhận
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      ref={bubbleRef}
+      type="button"
+      aria-label="Mở nhập giao dịch nhanh"
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={finishPointer}
+      onPointerCancel={finishPointer}
+      className="fixed z-[60] flex items-center justify-center rounded-full border border-white/35 bg-white/20 text-slate-800 shadow-xl backdrop-blur-xl transition duration-150 dark:border-white/10 dark:bg-slate-800/30 dark:text-white"
+      style={{
+        ...bubbleStyle,
+        width: `${FLOATING_SIZE}px`,
+        height: `${FLOATING_SIZE}px`,
+        opacity: isDragging ? 0.98 : 0.82,
+        transform: isDragging ? 'scale(1.1)' : 'scale(1)',
+      }}
+    >
+      <span className="text-3xl font-light leading-none">+</span>
+    </button>
+  );
+}

--- a/components/client/floating-quick-entry.tsx
+++ b/components/client/floating-quick-entry.tsx
@@ -12,6 +12,7 @@ type Position = {
 const FLOATING_SIZE = 56;
 const MARGIN = 16;
 const DRAG_THRESHOLD = 6;
+const STORAGE_KEY = 'owwi.newui:floating-quick-entry-position';
 
 export function FloatingQuickEntry() {
   const [isOpen, setIsOpen] = useState(false);
@@ -28,19 +29,6 @@ export function FloatingQuickEntry() {
     moved: false,
   });
 
-  useEffect(() => {
-    const syncInitialPosition = () => {
-      setPosition({
-        x: window.innerWidth - FLOATING_SIZE - MARGIN,
-        y: window.innerHeight - FLOATING_SIZE - 96,
-      });
-    };
-
-    syncInitialPosition();
-    window.addEventListener('resize', syncInitialPosition);
-    return () => window.removeEventListener('resize', syncInitialPosition);
-  }, []);
-
   const clampPosition = useCallback((nextX: number, nextY: number) => {
     const maxX = Math.max(MARGIN, window.innerWidth - FLOATING_SIZE - MARGIN);
     const maxY = Math.max(MARGIN, window.innerHeight - FLOATING_SIZE - MARGIN);
@@ -50,7 +38,42 @@ export function FloatingQuickEntry() {
     };
   }, []);
 
+  const savePosition = useCallback((next: Position) => {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+    } catch {
+      // ignore storage failures
+    }
+  }, []);
+
+  useEffect(() => {
+    const syncInitialPosition = () => {
+      const defaultPosition = {
+        x: window.innerWidth - FLOATING_SIZE - MARGIN,
+        y: window.innerHeight - FLOATING_SIZE - 96,
+      };
+
+      try {
+        const raw = window.localStorage.getItem(STORAGE_KEY);
+        if (!raw) {
+          setPosition(defaultPosition);
+          return;
+        }
+
+        const parsed = JSON.parse(raw) as Position;
+        setPosition(clampPosition(parsed.x, parsed.y));
+      } catch {
+        setPosition(defaultPosition);
+      }
+    };
+
+    syncInitialPosition();
+    window.addEventListener('resize', syncInitialPosition);
+    return () => window.removeEventListener('resize', syncInitialPosition);
+  }, [clampPosition]);
+
   const handlePointerDown = useCallback((event: React.PointerEvent<HTMLButtonElement>) => {
+    event.preventDefault();
     dragStateRef.current = {
       pointerId: event.pointerId,
       startX: event.clientX,
@@ -67,6 +90,7 @@ export function FloatingQuickEntry() {
     const state = dragStateRef.current;
     if (state.pointerId !== event.pointerId) return;
 
+    event.preventDefault();
     const deltaX = event.clientX - state.startX;
     const deltaY = event.clientY - state.startY;
     const distance = Math.hypot(deltaX, deltaY);
@@ -86,8 +110,13 @@ export function FloatingQuickEntry() {
     const state = dragStateRef.current;
     if (state.pointerId !== event.pointerId) return;
 
+    event.preventDefault();
     event.currentTarget.releasePointerCapture(event.pointerId);
     const didMove = state.moved;
+
+    if (didMove) {
+      savePosition(position);
+    }
 
     dragStateRef.current = {
       pointerId: -1,
@@ -103,7 +132,7 @@ export function FloatingQuickEntry() {
     if (!didMove) {
       setIsOpen(true);
     }
-  }, []);
+  }, [position, savePosition]);
 
   const bubbleStyle = useMemo(() => ({ left: `${position.x}px`, top: `${position.y}px` }), [position.x, position.y]);
 
@@ -153,16 +182,19 @@ export function FloatingQuickEntry() {
       onPointerMove={handlePointerMove}
       onPointerUp={finishPointer}
       onPointerCancel={finishPointer}
-      className="fixed z-[60] flex items-center justify-center rounded-full border border-white/35 bg-white/20 text-slate-800 shadow-xl backdrop-blur-xl transition duration-150 dark:border-white/10 dark:bg-slate-800/30 dark:text-white"
+      className="fixed z-[60] flex touch-none select-none items-center justify-center rounded-full border border-white/35 bg-white/20 text-slate-800 shadow-xl backdrop-blur-xl transition duration-150 dark:border-white/10 dark:bg-slate-800/30 dark:text-white"
       style={{
         ...bubbleStyle,
         width: `${FLOATING_SIZE}px`,
         height: `${FLOATING_SIZE}px`,
         opacity: isDragging ? 0.98 : 0.82,
         transform: isDragging ? 'scale(1.1)' : 'scale(1)',
+        WebkitUserSelect: 'none',
+        userSelect: 'none',
+        WebkitTouchCallout: 'none',
       }}
     >
-      <span className="text-3xl font-light leading-none">+</span>
+      <span className="pointer-events-none select-none text-3xl font-light leading-none">+</span>
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- Replace simplified floating quick entry UI with AddTransactionModal
- Keep draggable floating entry button behavior

## Test
- Scoped TypeScript check for touched modal/floating files passed